### PR TITLE
Remove Loop Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,32 +25,32 @@ use chrome_remote_interface::model::target::{CreateTargetCommand, AttachToTarget
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
+    pretty_env_logger::init();
     let browser = Browser::launcher()
         .headless(true) // headless mode (Default)
         .launch()
         .await?;
 
-    browser.run_with(|mut client| async move {
-        // Open new page
-        let response = client.request(CreateTargetCommand::builder()
-            .url("https://example.org/".into())
-            .build()
-            .unwrap()
-        ).await?;
+    let client = browser.connect().await?;
+    // Open new page
+    let response = client.request(CreateTargetCommand::builder()
+        .url("https://example.org/".into())
+        .build()
+        .unwrap()
+    ).await?;
 
-        // Attach opened page.
-        let response = client
-            .request(AttachToTargetCommand::new((*response).clone(), Some(true)))
-            .await?;
+    // Attach opened page.
+    let response = client
+        .request(AttachToTargetCommand::new((*response).clone(), Some(true)))
+        .await?;
 
-        // construct attached session.
-        let mut session = client.session(response);
+    // construct attached session.
+    let mut session = client.session(response);
 
-        // DO STUFF
-        // ...
+    // DO STUFF
+    // ...
 
-        Ok(())
-    }).await
+    Ok(())
 }
 ```
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,9 @@
+use futures::stream::StreamExt;
+
 use chrome_remote_interface::model::page::{self, CaptureScreenshotCommand, NavigateCommand};
 use chrome_remote_interface::model::runtime::EvaluateCommand;
 use chrome_remote_interface::model::target::{AttachToTargetCommand, CreateTargetCommand};
 use chrome_remote_interface::model::Event;
-
 use chrome_remote_interface::Browser;
 
 #[tokio::main(flavor = "current_thread")]

--- a/model/tools/src/render.rs
+++ b/model/tools/src/render.rs
@@ -1064,6 +1064,7 @@ mod protocol {
             #![allow(clippy::many_single_char_names)]
             #![allow(clippy::new_without_default)]
             #![allow(clippy::wrong_self_convention)]
+            #![warn(rustdoc::bare_urls)]
 
             use std::iter::{IntoIterator, FromIterator};
             use std::ops::Deref;

--- a/model/tools/src/render/tests.rs
+++ b/model/tools/src/render/tests.rs
@@ -64,6 +64,7 @@ fn test_protocol() {
             #![allow(clippy::many_single_char_names)]
             #![allow(clippy::new_without_default)]
             #![allow(clippy::wrong_self_convention)]
+            #![warn(rustdoc::bare_urls)]
             use std::iter::{IntoIterator, FromIterator};
             use std::ops::Deref;
             use serde::{Serialize, Deserialize};

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -302,14 +302,14 @@ impl Browser {
     /// Connect Chrome DevTools Protocol Client.
     ///
     /// This instance Ownership move to Client.
-    pub async fn connect(mut self) -> super::Result<super::Client> {
+    pub async fn connect(mut self) -> super::Result<super::CdpClient> {
         let maybe_channel = match &mut self.remote_debugging {
             RemoteDebugging::Ws => None,
             RemoteDebugging::Pipe(inner) => Some(inner.take().unwrap().into()),
         };
         match maybe_channel {
-            None => super::Client::connect_ws(&self.cdp_url().await?, Some(self)).await,
-            Some(channel) => Ok(super::Client::connect_pipe(self, channel)),
+            None => super::CdpClient::connect_ws(&self.cdp_url().await?, Some(self)).await,
+            Some(channel) => Ok(super::CdpClient::connect_pipe(self, channel)),
         }
     }
 }

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,11 +1,9 @@
 use std::env;
-use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use dirs::home_dir;
-use futures::TryFutureExt;
 use tempfile::TempDir;
 use tokio::fs::{create_dir_all, metadata, File};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -304,28 +302,15 @@ impl Browser {
     /// Connect Chrome DevTools Protocol Client.
     ///
     /// This instance Ownership move to Client.
-    pub async fn connect(mut self) -> super::Result<(super::CdpClient, super::Loop)> {
+    pub async fn connect(mut self) -> super::Result<super::Client> {
         let maybe_channel = match &mut self.remote_debugging {
             RemoteDebugging::Ws => None,
             RemoteDebugging::Pipe(inner) => Some(inner.take().unwrap().into()),
         };
         match maybe_channel {
-            None => super::CdpClient::connect_ws(&self.cdp_url().await?, Some(self)).await,
-            Some(channel) => super::CdpClient::connect_pipe(self, channel).await,
+            None => super::Client::connect_ws(&self.cdp_url().await?, Some(self)).await,
+            Some(channel) => Ok(super::Client::connect_pipe(self, channel)),
         }
-    }
-
-    /// Connect Chrome DevTools Protocol Client and run async block.
-    pub async fn run_with<F, E, R, Fut>(self, fun: F) -> std::result::Result<R, E>
-    where
-        F: FnOnce(super::CdpClient) -> Fut,
-        E: From<super::Error>,
-        Fut: Future<Output = std::result::Result<R, E>>,
-    {
-        let (client, r#loop) = self.connect().await?;
-        let (_, result) = tokio::try_join!(r#loop.map_err(E::from), fun(client))?;
-
-        Ok(result)
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,349 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::ops::{Deref, DerefMut};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
+
+use super::model;
+use futures::channel::mpsc;
+use futures::lock::Mutex;
+use futures::stream::{SplitSink, SplitStream};
+use futures::{FutureExt, SinkExt, Stream, StreamExt};
+use serde_json::Value as JsonValue;
+use url::Url;
+
+struct ReceiveInner<S>
+where
+    S: Stream<Item = super::Result<model::Response>>,
+{
+    stream: S,
+    wakers: Vec<Waker>,
+    head: Option<super::Result<model::Response>>,
+    subscribers: HashMap<Option<model::SessionId>, Vec<mpsc::UnboundedSender<model::Event>>>,
+}
+
+struct Recv<S>
+where
+    S: Stream<Item = super::Result<model::Response>>,
+{
+    inner: Arc<Mutex<ReceiveInner<S>>>,
+    session_id: Option<model::SessionId>,
+    id: u32,
+}
+
+impl<S> Future for Recv<S>
+where
+    S: Stream<Item = super::Result<model::Response>> + Unpin,
+{
+    type Output = super::Result<Option<JsonValue>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {
+            let mut inner = match self.inner.lock().poll_unpin(cx) {
+                Poll::Ready(inner) => inner,
+                Poll::Pending => return Poll::Pending,
+            };
+
+            match &inner.head {
+                Some(Ok(model::Response::Event(..))) => unreachable!(),
+                Some(Ok(
+                    model::Response::Return(session_id, id, _)
+                    | model::Response::Error(session_id, id, _),
+                )) if *session_id == self.session_id && *id == self.id => {
+                    match inner.head.take().unwrap().unwrap() {
+                        model::Response::Return(_, _, v) => return Poll::Ready(Ok(Some(v))),
+                        model::Response::Error(_, _, v) => {
+                            return Poll::Ready(Err(super::Error::Response(v)))
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+                Some(Ok(model::Response::Return(..) | model::Response::Error(..))) => {
+                    inner.wakers.push(cx.waker().clone());
+                    return Poll::Pending;
+                }
+                Some(Err(err)) => {
+                    return Poll::Ready(Err(super::Error::TransportBroken(format!("{}", err))));
+                }
+                None => {}
+            }
+
+            let result = match inner.stream.poll_next_unpin(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(result) => result,
+            };
+
+            for w in inner.wakers.drain(..) {
+                w.wake();
+            }
+
+            match result {
+                Some(Ok(model::Response::Event(session_id, event))) => {
+                    for tx in inner.subscribers.entry(session_id).or_default() {
+                        tx.unbounded_send(event.clone()).ok();
+                    }
+                }
+                Some(response) => inner.head = Some(response),
+                None => {
+                    inner.subscribers.clear();
+                    return Poll::Ready(Ok(None));
+                }
+            }
+        }
+    }
+}
+
+struct Next<S>
+where
+    S: Stream<Item = super::Result<model::Response>>,
+{
+    inner: Arc<Mutex<ReceiveInner<S>>>,
+}
+
+impl<S> Future for Next<S>
+where
+    S: Stream<Item = super::Result<model::Response>> + Unpin,
+{
+    type Output = Option<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut inner = match self.inner.lock().poll_unpin(cx) {
+            Poll::Ready(inner) => inner,
+            Poll::Pending => return Poll::Pending,
+        };
+
+        let result = match inner.stream.poll_next_unpin(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(result) => result,
+        };
+
+        if inner.head.is_some() {
+            inner.wakers.push(cx.waker().clone());
+            return Poll::Pending;
+        }
+
+        for w in inner.wakers.drain(..) {
+            w.wake();
+        }
+
+        match result {
+            Some(Ok(model::Response::Event(session_id, event))) => {
+                for tx in inner.subscribers.entry(session_id).or_default() {
+                    tx.unbounded_send(event.clone()).ok();
+                }
+            }
+            Some(response) => inner.head = Some(response),
+            None => {
+                inner.subscribers.clear();
+                return Poll::Ready(None);
+            }
+        }
+        Poll::Ready(Some(()))
+    }
+}
+
+struct Receive<S>(Arc<Mutex<ReceiveInner<S>>>)
+where
+    S: Stream<Item = super::Result<model::Response>>;
+
+impl<S> Clone for Receive<S>
+where
+    S: Stream<Item = super::Result<model::Response>>,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<S> Receive<S>
+where
+    S: Stream<Item = super::Result<model::Response>> + Unpin,
+{
+    fn recv(&self, session_id: Option<model::SessionId>, id: u32) -> Recv<S> {
+        Recv {
+            inner: self.0.clone(),
+            session_id,
+            id,
+        }
+    }
+
+    fn next(&self) -> Next<S> {
+        Next {
+            inner: self.0.clone(),
+        }
+    }
+
+    async fn subscribe(
+        &self,
+        session_id: Option<super::SessionId>,
+    ) -> mpsc::UnboundedReceiver<model::Event> {
+        let (tx, rx) = mpsc::unbounded();
+
+        let mut inner = self.0.lock().await;
+        inner
+            .subscribers
+            .entry(session_id)
+            .or_insert_with(Vec::new)
+            .push(tx);
+        rx
+    }
+}
+
+struct CvtChannel(SplitStream<super::Channel>);
+
+impl Stream for CvtChannel {
+    type Item = super::Result<model::Response>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.get_mut().0.poll_next_unpin(cx)? {
+            Poll::Ready(Some(json)) => Poll::Ready(Some(Ok(serde_json::from_value(json)?))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Stream for Chrome DevTools Protocol Event.
+pub struct Events {
+    receive: Receive<CvtChannel>,
+    rx: mpsc::UnboundedReceiver<model::Event>,
+}
+
+impl Events {
+    pub async fn next(&mut self) -> Option<model::Event> {
+        loop {
+            match self.rx.try_next() {
+                Ok(Some(evt)) => return Some(evt),
+                Ok(None) => return None,
+                Err(..) => {}
+            }
+            self.receive.next().await?;
+        }
+    }
+}
+
+pub struct Session {
+    idgen: Arc<AtomicU32>,
+    session_id: Option<model::SessionId>,
+    rx: Receive<CvtChannel>,
+    tx: Arc<Mutex<SplitSink<super::Channel, JsonValue>>>,
+    browser: Option<Arc<Mutex<super::Browser>>>,
+}
+
+impl Session {
+    fn new(channel: super::Channel, browser: Option<super::Browser>) -> Self {
+        let (tx, rx) = channel.split();
+        let rx = CvtChannel(rx);
+        let rx = Receive(Arc::new(Mutex::new(ReceiveInner {
+            stream: rx,
+            wakers: Default::default(),
+            head: None,
+            subscribers: Default::default(),
+        })));
+        let tx = Arc::new(Mutex::new(tx));
+        let browser = browser.map(Mutex::new).map(Arc::new);
+        Self {
+            idgen: Arc::new(Default::default()),
+            session_id: None,
+            rx,
+            tx,
+            browser,
+        }
+    }
+
+    fn session_for(&self, session_id: model::SessionId) -> Self {
+        Self {
+            idgen: self.idgen.clone(),
+            session_id: Some(session_id),
+            rx: Receive(self.rx.0.clone()),
+            tx: self.tx.clone(),
+            browser: self.browser.clone(),
+        }
+    }
+
+    async fn request_inner<C>(
+        command: C,
+        tx: Arc<Mutex<SplitSink<super::Channel, JsonValue>>>,
+        rx: Receive<CvtChannel>,
+        session_id: Option<model::SessionId>,
+        id: u32,
+    ) -> super::Result<C::Return>
+    where
+        C: model::Command,
+    {
+        let request = command.into_request(session_id.clone(), id);
+        let request = serde_json::to_value(request)?;
+
+        let mut tx = tx.lock().await;
+        tx.send(request).await?;
+
+        let result = rx.recv(session_id, id).await?;
+        let result = result.unwrap(); // TODO eof
+        let result = serde_json::from_value(result)?;
+        Ok(result)
+    }
+
+    /// Request for Chrome DevTools Protocol Command.
+    pub fn request<C>(&self, command: C) -> impl Future<Output = super::Result<C::Return>> + 'static
+    where
+        C: model::Command + 'static,
+    {
+        let id = self.idgen.fetch_add(1, Ordering::SeqCst);
+
+        let tx = self.tx.clone();
+        let rx = self.rx.clone();
+        let session_id = self.session_id.clone();
+
+        Self::request_inner(command, tx, rx, session_id, id)
+    }
+
+    pub async fn events(&self) -> Events {
+        let rx = self.rx.subscribe(self.session_id.clone()).await;
+        Events {
+            receive: Receive(self.rx.0.clone()),
+            rx,
+        }
+    }
+}
+
+pub struct Client {
+    session: Session,
+}
+
+impl Client {
+    pub async fn connect_ws(url: &Url, browser: Option<super::Browser>) -> super::Result<Self> {
+        let (ws, _) = tokio_tungstenite::connect_async(url).await?;
+        let channel = super::Channel::Ws(ws.fuse());
+        let session = Session::new(channel, browser);
+        Ok(Self { session })
+    }
+
+    pub(crate) fn connect_pipe(browser: super::Browser, channel: super::pipe::PipeChannel) -> Self {
+        let channel = super::Channel::Pipe(channel);
+        let session = Session::new(channel, Some(browser));
+        Self { session }
+    }
+
+    pub fn session<S>(&self, session_id: S) -> Session
+    where
+        S: Deref<Target = model::target::SessionId>,
+    {
+        self.session
+            .session_for(model::SessionId::from(session_id.as_ref()))
+    }
+}
+
+impl Deref for Client {
+    type Target = Session;
+    fn deref(&self) -> &Self::Target {
+        &self.session
+    }
+}
+
+impl DerefMut for Client {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.session
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,9 @@
 //!
 //! Licensed under either of
 //! * Apache License, Version 2.0
-//!   ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+//!   ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 //! * MIT license
-//!   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+//!   ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 //! at your option.
 //!
 //! ## Contribution

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ use model::SessionId;
 /// Environment variable key for Browser Path.
 pub const BROWSER_BIN: &str = "CRI_CHROME_BIN";
 
-pub use client::{Client, Session};
+pub use client::{Client as CdpClient, Events as CdpEvents, Session as CdpSession};
 
 macro_rules! recv {
     ($len:expr, $content:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,27 +17,26 @@
 //!         .launch()
 //!         .await?;
 //!
-//!     browser.run_with(|mut client| async move {
-//!         // Open new page
-//!         let response = client.request(CreateTargetCommand::builder()
-//!             .url("https://example.org/".into())
-//!             .build()
-//!             .unwrap()
-//!         ).await?;
+//!     let client = browser.connect().await?;
+//!     // Open new page
+//!     let response = client.request(CreateTargetCommand::builder()
+//!         .url("https://example.org/".into())
+//!         .build()
+//!         .unwrap()
+//!     ).await?;
 //!
-//!         // Attach opened page.
-//!         let response = client
-//!             .request(AttachToTargetCommand::new((*response).clone(), Some(true)))
-//!             .await?;
+//!     // Attach opened page.
+//!     let response = client
+//!         .request(AttachToTargetCommand::new((*response).clone(), Some(true)))
+//!         .await?;
 //!
-//!         // construct attached session.
-//!         let mut session = client.session(response);
+//!     // construct attached session.
+//!     let mut session = client.session(response);
 //!
-//!         // DO STUFF
-//!         // ...
+//!     // DO STUFF
+//!     // ...
 //!
-//!         Ok(())
-//!     }).await
+//!     Ok(())
 //! }
 //! ```
 //!
@@ -56,30 +55,17 @@
 //! for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 //! dual licensed as above, without any additional terms or conditions.!
 
-use std::collections::HashMap;
-use std::future::Future;
 use std::io;
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::channel::mpsc;
-use futures::channel::oneshot;
-use futures::future::FutureExt;
 use futures::ready;
-use futures::select;
 use futures::sink::{Sink, SinkExt};
 use futures::stream::{Fuse, Stream, StreamExt};
-use serde::Deserialize;
 use serde_json::Value;
 use tokio::net::TcpStream;
-use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::protocol::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
-use url::Url;
 
 pub use browser::*;
 pub use chrome_remote_interface_model as model;
@@ -87,6 +73,8 @@ use model::SessionId;
 
 /// Environment variable key for Browser Path.
 pub const BROWSER_BIN: &str = "CRI_CHROME_BIN";
+
+pub use client::{Client, Session};
 
 macro_rules! recv {
     ($len:expr, $content:expr) => {
@@ -101,6 +89,7 @@ macro_rules! send {
 }
 
 mod browser;
+mod client;
 pub(crate) mod os;
 mod pipe;
 pub(crate) mod process;
@@ -124,23 +113,13 @@ pub enum Error {
     #[error("error response {0:?}")]
     Response(serde_json::Value),
 
-    /// Loop Cancelation Error.
-    #[error("loop canceled")]
-    LoopCanceled(#[from] oneshot::Canceled),
-
-    /// Maybe Loop Aborted Error.
-    #[error("loop aborted")]
-    LoopAborted(#[from] mpsc::SendError),
-
     /// Browser Error.
     #[error(transparent)]
     Browser(#[from] BrowserError),
-}
 
-impl<T> From<mpsc::TrySendError<T>> for Error {
-    fn from(v: mpsc::TrySendError<T>) -> Self {
-        Self::LoopAborted(v.into_send_error())
-    }
+    /// Browser Error.
+    #[error("transport broken: {0}")]
+    TransportBroken(String),
 }
 
 /// Chrome DevTools Protocol Result.
@@ -223,277 +202,5 @@ impl Sink<Value> for Channel {
 
             Self::Pipe(inner) => inner.poll_close_unpin(cx),
         }
-    }
-}
-
-/// Stream for Chrome DevTools Protocol Event.
-#[derive(Debug)]
-pub struct CdpEvents {
-    rx: mpsc::UnboundedReceiver<model::Event>,
-}
-
-impl Stream for CdpEvents {
-    type Item = model::Event;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.rx.poll_next_unpin(cx)
-    }
-}
-
-/// Chrome DevTools Protocol Client Command Request Future.
-#[derive(Debug)]
-pub struct Request<R> {
-    tx_result: Option<Result<()>>,
-    rx: oneshot::Receiver<std::result::Result<Value, Value>>,
-    _phantom: PhantomData<R>,
-}
-
-impl<R> Future for Request<R>
-where
-    R: for<'r> Deserialize<'r> + Unpin,
-{
-    type Output = Result<R>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-        if let Some(r) = this.tx_result.take() {
-            r?;
-        }
-        match ready!(this.rx.poll_unpin(cx))? {
-            Ok(v) => Poll::Ready(Ok(serde_json::from_value(v)?)),
-            Err(err) => Poll::Ready(Err(Error::Response(err))),
-        }
-    }
-}
-
-/// Chrome DevTools Protocol Session.
-#[derive(Debug, Clone)]
-pub struct CdpSession {
-    idgen: Arc<AtomicU32>,
-    session_id: Option<SessionId>,
-    control_tx: mpsc::UnboundedSender<Control>,
-    browser: Option<Arc<Mutex<Browser>>>,
-}
-
-impl CdpSession {
-    /// Request for Chrome DevTools Protocol Command.
-    pub fn request<C>(&mut self, command: C) -> Request<C::Return>
-    where
-        C: model::Command,
-    {
-        let id = self.idgen.fetch_add(1, Ordering::SeqCst);
-        let request = command.into_request(self.session_id.clone(), id);
-        let request = serde_json::to_value(&request).unwrap(); // FIXME
-        let (tx, rx) = oneshot::channel();
-        let tx_result = self
-            .control_tx
-            .unbounded_send(Control::Request(id, request, tx));
-
-        Request {
-            tx_result: Some(tx_result.map_err(Into::into)),
-            rx,
-            _phantom: PhantomData,
-        }
-    }
-
-    /// Subscribe Chrome DevTools Protocol Event.
-    pub fn events(&mut self) -> Result<CdpEvents> {
-        let (tx, rx) = mpsc::unbounded();
-        self.control_tx
-            .unbounded_send(Control::Subscribe(self.session_id.clone(), tx))?;
-        Ok(CdpEvents { rx })
-    }
-}
-
-async fn wait(browser: &Option<Arc<Mutex<Browser>>>) -> io::Result<()> {
-    if let Some(browser) = browser {
-        let mut browser = browser.lock().await;
-        browser.wait().await
-    } else {
-        std::future::pending::<()>().await;
-        Ok(())
-    }
-}
-
-async fn loop_inner(
-    control_rx: &mut mpsc::UnboundedReceiver<Control>,
-    channel: &mut Channel,
-    browser: Option<Arc<Mutex<Browser>>>,
-) -> Result<()> {
-    let mut waiters = HashMap::<u32, oneshot::Sender<std::result::Result<Value, Value>>>::new();
-    let mut events = HashMap::<Option<SessionId>, Vec<mpsc::UnboundedSender<model::Event>>>::new();
-
-    loop {
-        select! {
-            _ = wait(&browser).fuse() => {
-                // FIXME There may be some events that we're not receiving.
-                break
-            },
-
-            ctrl = control_rx.next() => {
-                match ctrl {
-                    Some(Control::Subscribe(session_id, tx)) => {
-                        events.entry(session_id).or_insert_with(Default::default).push(tx);
-                    }
-                    Some(Control::Request(id, request, result)) => {
-                        channel.send(request).await?;
-                        waiters.insert(id, result);
-                    }
-                    None => break,
-                }
-            },
-
-            msg = channel.next().fuse() => {
-                match msg {
-                    Some(Ok(msg)) => {
-                        let msg = serde_json::from_value(msg)?;
-                        match msg {
-                            model::Response::Event(session_id, evt) => {
-                                for tx in &mut *events.entry(session_id).or_default() {
-                                    tx.unbounded_send(evt.clone()).ok(); // TODO remove
-                                }
-                            }
-
-                            model::Response::Return(_, id, v) => {
-                                if let Some(tx) = waiters.remove(&id) {
-                                    tx.send(Ok(v)).unwrap();
-                                }
-                            }
-
-                            model::Response::Error(_, id, err) => {
-                                if let Some(tx) = waiters.remove(&id) {
-                                    tx.send(Err(err)).unwrap();
-                                }
-                            }
-                        }
-                    }
-                    Some(Err(err)) => return Err(err),
-                    None => {}
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-async fn r#loop(
-    mut control_rx: mpsc::UnboundedReceiver<Control>,
-    mut channel: Channel,
-    browser: Option<Arc<Mutex<Browser>>>,
-) -> Result<()> {
-    log::debug!("Begin loop.");
-
-    let result = loop_inner(&mut control_rx, &mut channel, browser.clone()).await;
-
-    if let Some(browser) = browser {
-        log::debug!("send close command.");
-        let close_command = model::browser::CloseCommand::new();
-        let close_command = model::Command::into_request(close_command, None, 0);
-        if let Ok(close_command) = serde_json::to_value(close_command) {
-            channel.send(close_command).await.ok();
-        }
-
-        log::debug!("browser shutdown.");
-        browser.lock().await.close().await;
-    }
-    log::debug!("Loop done.");
-
-    result
-}
-
-#[derive(Debug)]
-enum Control {
-    Subscribe(Option<SessionId>, mpsc::UnboundedSender<model::Event>),
-    Request(
-        u32,
-        Value,
-        oneshot::Sender<std::result::Result<Value, Value>>,
-    ),
-}
-
-/// Message loop.
-pub struct Loop {
-    future: Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
-}
-
-impl Future for Loop {
-    type Output = Result<()>;
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.future.poll_unpin(cx)
-    }
-}
-
-/// Chrome DevTools Protocol Client.
-///
-/// This serve as browser session.
-#[derive(Debug)]
-pub struct CdpClient {
-    control_tx: mpsc::UnboundedSender<Control>,
-    session: CdpSession,
-}
-
-impl CdpClient {
-    async fn connect_internal(channel: Channel, browser: Option<Browser>) -> (Self, Loop) {
-        let browser = browser.map(|b| Arc::new(Mutex::new(b)));
-
-        let (control_tx, control_rx) = mpsc::unbounded();
-        let task = Loop {
-            future: Box::pin(r#loop(control_rx, channel, browser.clone())),
-        };
-        let session = CdpSession {
-            idgen: Arc::new(AtomicU32::default()),
-            session_id: None,
-            control_tx: control_tx.clone(),
-            browser,
-        };
-        let client = CdpClient {
-            control_tx,
-            session,
-        };
-        (client, task)
-    }
-
-    /// Connect with CDP Websocket.
-    pub async fn connect(url: &Url) -> Result<(Self, impl Future<Output = Result<()>>)> {
-        Self::connect_ws(url, None).await
-    }
-
-    async fn connect_ws(url: &Url, browser: Option<Browser>) -> Result<(Self, Loop)> {
-        let (ws, _) = tokio_tungstenite::connect_async(url).await?;
-        let channel = Channel::Ws(ws.fuse());
-        Ok(Self::connect_internal(channel, browser).await)
-    }
-
-    async fn connect_pipe(browser: Browser, channel: pipe::PipeChannel) -> Result<(Self, Loop)> {
-        let channel = Channel::Pipe(channel);
-        Ok(Self::connect_internal(channel, Some(browser)).await)
-    }
-
-    /// Construct session with target.
-    pub fn session<S: Deref<Target = model::target::SessionId>>(
-        &mut self,
-        session_id: S,
-    ) -> CdpSession {
-        let session_id = Some(SessionId::from(session_id.as_ref()));
-        CdpSession {
-            idgen: self.idgen.clone(),
-            session_id,
-            control_tx: self.control_tx.clone(),
-            browser: self.browser.clone(),
-        }
-    }
-}
-
-impl Deref for CdpClient {
-    type Target = CdpSession;
-    fn deref(&self) -> &Self::Target {
-        &self.session
-    }
-}
-
-impl DerefMut for CdpClient {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.session
     }
 }

--- a/tests/connect_default.rs
+++ b/tests/connect_default.rs
@@ -5,6 +5,7 @@ async fn connect_default() -> anyhow::Result<()> {
     pretty_env_logger::init();
 
     let browser = Browser::launcher().output(true).launch().await?;
-
-    browser.run_with(|_| async { Ok(()) }).await
+    let client = browser.connect().await?;
+    drop(client);
+    Ok(())
 }

--- a/tests/connect_ws.rs
+++ b/tests/connect_ws.rs
@@ -9,6 +9,7 @@ async fn connect_ws() -> anyhow::Result<()> {
         .use_pipe(false)
         .launch()
         .await?;
-
-    browser.run_with(|_| async { Ok(()) }).await
+    let client = browser.connect().await?;
+    drop(client);
+    Ok(())
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -9,34 +9,29 @@ async fn test_simple() -> anyhow::Result<()> {
         .headless(true) // headless mode (Default)
         .launch()
         .await?;
+    let client = browser.connect().await?;
 
-    browser
-        .run_with(|mut client| async move {
-            // Open new page
-            let response = client
-                .request(
-                    CreateTargetCommand::builder()
-                        .url("https://example.org/".into())
-                        .build()
-                        .unwrap(),
-                )
-                .await?;
-
-            // Attach opened page.
-            let response = client
-                .request(AttachToTargetCommand::new((*response).clone(), Some(true)))
-                .await?;
-
-            // construct attached session.
-            let session = client.session(response);
-
-            // DO STUFF
-            // ...
-            drop(session);
-
-            anyhow::Result::<_>::Ok(())
-        })
+    // Open new page
+    let response = client
+        .request(
+            CreateTargetCommand::builder()
+                .url("https://example.org/".into())
+                .build()
+                .unwrap(),
+        )
         .await?;
+
+    // Attach opened page.
+    let response = client
+        .request(AttachToTargetCommand::new((*response).clone(), Some(true)))
+        .await?;
+
+    // construct attached session.
+    let session = client.session(response);
+
+    // DO STUFF
+    // ...
+    drop(session);
 
     Ok(())
 }

--- a/tests/twice.rs
+++ b/tests/twice.rs
@@ -17,31 +17,27 @@ async fn proc() -> anyhow::Result<()> {
         .launch()
         .await?;
 
-    browser
-        .run_with(|mut client| async move {
-            // Open new page
-            let response = client
-                .request(
-                    CreateTargetCommand::builder()
-                        .url("https://example.org/".into())
-                        .build()
-                        .unwrap(),
-                )
-                .await?;
+    let client = browser.connect().await?;
+    // Open new page
+    let response = client
+        .request(
+            CreateTargetCommand::builder()
+                .url("https://example.org/".into())
+                .build()
+                .unwrap(),
+        )
+        .await?;
 
-            // Attach opened page.
-            let response = client
-                .request(AttachToTargetCommand::new((*response).clone(), Some(true)))
-                .await?;
+    // Attach opened page.
+    let response = client
+        .request(AttachToTargetCommand::new((*response).clone(), Some(true)))
+        .await?;
 
-            // construct attached session.
-            let session = client.session(response);
+    // construct attached session.
+    let session = client.session(response);
 
-            // DO STUFF
-            // ...
-            drop(session);
-
-            Ok(())
-        })
-        .await
+    // DO STUFF
+    // ...
+    drop(session);
+    Ok(())
 }


### PR DESCRIPTION
Breaking change.

# Remove

`Loop`

# Changes

`Browser::connect` returns (CdpClient, Loop) -> CdpClient
`CdpClient::connect_ws` return (CdpClient, Loop) -> CdpClient

And servial changes.