### PR TITLE
remove internal ws transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ path = "model"
 
 [dev-dependencies]
 anyhow = "1.0"
-tokio = { version = "1.0", features = ["rt", "macros"] }
+tokio = { version = "1.0", features = ["rt", "macros", "net"] }
 pretty_env_logger = "0.4"
 
 [features]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -15,7 +15,7 @@ async fn main() -> anyhow::Result<()> {
         .output(true)
         .launch()
         .await?;
-    let client = browser.connect().await?;
+    let client = browser.connect();
 
     let mut events = client.events().await;
     tokio::spawn(async move {

--- a/src/client.rs
+++ b/src/client.rs
@@ -323,10 +323,10 @@ pub struct Client {
 
 impl Client {
     /// Connect with CDP Websocket.
-    pub async fn connect_ws(url: &Url, browser: Option<super::Browser>) -> super::Result<Self> {
+    pub async fn connect_ws(url: &Url) -> super::Result<Self> {
         let (ws, _) = tokio_tungstenite::connect_async(url).await?;
         let channel = super::Channel::Ws(ws.fuse());
-        let session = Session::new(channel, browser);
+        let session = Session::new(channel, None);
         Ok(Self { session })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!         .launch()
 //!         .await?;
 //!
-//!     let client = browser.connect().await?;
+//!     let client = browser.connect();
 //!     // Open new page
 //!     let response = client.request(CreateTargetCommand::builder()
 //!         .url("https://example.org/".into())

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -111,16 +111,6 @@ pub async fn spawn_with_pipe(builder: ProcessBuilder) -> io::Result<(OsProcess, 
     Ok((proc, OsPipe::new(their_input, their_output)))
 }
 
-pub fn spawn(builder: ProcessBuilder) -> io::Result<OsProcess> {
-    let proc = Command::new(builder.get_program())
-        .args(builder.get_args())
-        .stdin(Stdio::from(builder.get_stdin()))
-        .stdout(Stdio::from(builder.get_stdout()))
-        .stderr(Stdio::from(builder.get_stderr()))
-        .spawn()?;
-    Ok(proc)
-}
-
 pub async fn proc_kill(mut proc: OsProcess) {
     if let Some(pid) = proc.id() {
         let pid = Pid::from_raw(pid as i32);
@@ -135,10 +125,6 @@ pub fn proc_kill_sync(proc: OsProcess) {
         kill(pid, Some(SIGTERM)).ok(); // FIXME
         waitpid(Some(pid), None).ok(); // FIXME blocking
     }
-}
-
-pub fn try_wait(proc: &mut OsProcess) -> io::Result<bool> {
-    Ok(proc.try_wait()?.is_some())
 }
 
 pub async fn wait(proc: &mut OsProcess) -> io::Result<()> {

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -38,10 +38,6 @@ pub async fn spawn_with_pipe(builder: ProcessBuilder) -> io::Result<(OsProcess, 
     Ok((child, OsPipe::new(pipein, pipeout)))
 }
 
-pub fn spawn(builder: ProcessBuilder) -> io::Result<OsProcess> {
-    spawn_local(&builder)
-}
-
 fn spawn_local(builder: &ProcessBuilder) -> io::Result<OsProcess> {
     with_stdio(builder.get_stdin(), Mode::ReadOnly, 0, move || {
         with_stdio(builder.get_stdout(), Mode::WriteOnly, 1, move || {
@@ -73,10 +69,6 @@ pub async fn proc_kill(mut proc: OsProcess) {
 
 pub fn proc_kill_sync(mut proc: OsProcess) {
     proc.kill().ok();
-}
-
-pub fn try_wait(proc: &mut OsProcess) -> io::Result<bool> {
-    Ok(proc.try_wait()?.is_some())
 }
 
 pub async fn wait(proc: &mut OsProcess) -> io::Result<()> {

--- a/src/process.rs
+++ b/src/process.rs
@@ -117,10 +117,6 @@ impl ProcessBuilder {
             .await
             .map(|(proc, pipe)| (Process(proc), pipe))
     }
-
-    pub fn spawn(self) -> io::Result<Process> {
-        os::spawn(self).map(Process)
-    }
 }
 
 #[derive(Debug)]
@@ -133,10 +129,6 @@ impl Process {
 
     pub fn kill_sync(self) {
         os::proc_kill_sync(self.0)
-    }
-
-    pub fn try_wait(&mut self) -> io::Result<bool> {
-        os::try_wait(&mut self.0)
     }
 
     pub async fn wait(&mut self) -> io::Result<()> {

--- a/tests/connect_default.rs
+++ b/tests/connect_default.rs
@@ -5,7 +5,7 @@ async fn connect_default() -> anyhow::Result<()> {
     pretty_env_logger::init();
 
     let browser = Browser::launcher().output(true).launch().await?;
-    let client = browser.connect().await?;
+    let client = browser.connect();
     drop(client);
     Ok(())
 }

--- a/tests/connect_ws.rs
+++ b/tests/connect_ws.rs
@@ -1,15 +1,25 @@
-use chrome_remote_interface::Browser;
+use chrome_remote_interface::CdpClient;
+use futures::channel::oneshot;
+use tokio::net::TcpListener;
 
 #[tokio::test]
 async fn connect_ws() -> anyhow::Result<()> {
     pretty_env_logger::init();
 
-    let browser = Browser::launcher()
-        .output(true)
-        .use_pipe(false)
-        .launch()
-        .await?;
-    let client = browser.connect().await?;
-    drop(client);
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await?;
+        let stream = tokio_tungstenite::accept_async(stream).await?;
+        drop(stream);
+        tx.send(()).unwrap();
+        anyhow::Result::<_>::Ok(())
+    });
+
+    CdpClient::connect_ws(&format!("ws://127.0.0.1:{}", addr.port()).parse()?).await?;
+    rx.await?;
+
     Ok(())
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -9,7 +9,7 @@ async fn test_simple() -> anyhow::Result<()> {
         .headless(true) // headless mode (Default)
         .launch()
         .await?;
-    let client = browser.connect().await?;
+    let client = browser.connect();
 
     // Open new page
     let response = client

--- a/tests/twice.rs
+++ b/tests/twice.rs
@@ -17,7 +17,7 @@ async fn proc() -> anyhow::Result<()> {
         .launch()
         .await?;
 
-    let client = browser.connect().await?;
+    let client = browser.connect();
     // Open new page
     let response = client
         .request(


### PR DESCRIPTION
Breaking changes.

# Remove

`Launcher::pipe` .. In the method of starting from the browser, support for Web Socket was abolished and only pipes were used.